### PR TITLE
Fixed symbol conflict on iOS 18 UIViewController.tab

### DIFF
--- a/Alderis/ColorPickerInnerViewController.swift
+++ b/Alderis/ColorPickerInnerViewController.swift
@@ -27,7 +27,7 @@ internal class ColorPickerInnerViewController: UIViewController {
 	let configuration: ColorPickerConfiguration
 	var color: Color
 
-	var tab: ColorPickerTab {
+	var colorPickerTab: ColorPickerTab {
 		get { configuration.visibleTabs[currentTab] }
 		set { currentTab = configuration.visibleTabs.firstIndex(of: newValue) ?? 0 }
 	}
@@ -299,7 +299,7 @@ internal class ColorPickerInnerViewController: UIViewController {
 		}
 
 		colorDidChange()
-		tab = configuration.initialTab
+		colorPickerTab = configuration.initialTab
 		tabsView?.selectedSegmentIndex = currentTab
 	}
 


### PR DESCRIPTION
iOS 18 adds a new property on `UIViewController` `weak var tab: [UITab]?`. This conflicts with `var tab: ColorPickerTab` on the `ColorPickerConfiguration` class. This commit simply renames the property from `tab` to `colorPickerTab` in order to resolve the conflict.